### PR TITLE
feat: Move BookWhen booking widget after locations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,14 @@
                         </div>
                     </div>
                     
+                    <!-- Bookwhen Booking System -->
+                    <div class="bookwhen-section">
+                        <h3>Book Your Session</h3>
+                        <div id="bookwhen-container" class="bookwhen-container">
+                            <!-- Bookwhen iframe will be inserted here -->
+                        </div>
+                    </div>
+                    
                     <!-- Class Information -->
                     <div class="class-info">
                         <h3>What to Expect</h3>
@@ -179,14 +187,6 @@
                                 <li>Cleaning supplies</li>
                                 <li>Hand sanitizer & paper towels</li>
                             </ul>
-                        </div>
-                    </div>
-                    
-                    <!-- Bookwhen Booking System -->
-                    <div class="bookwhen-section">
-                        <h3>Book Your Session</h3>
-                        <div id="bookwhen-container" class="bookwhen-container">
-                            <!-- Bookwhen iframe will be inserted here -->
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Relocate the "Book Your Session" BookWhen widget to appear immediately after the "Our Locations" section for better user flow. This places the booking functionality right after users see the venue information, creating a more logical progression from location details to booking.

🤖 Generated with [Claude Code](https://claude.ai/code)